### PR TITLE
Patch Issue #11

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,6 +12,5 @@ Famelo:
 TYPO3:
   Flow:
     object:
-      excludeClasses:
-        'knplabs.*': ['.*']
-        'itbz.*': ['.*']
+      includeClasses:
+        'mpdf.*': ['.*']


### PR DESCRIPTION
Replaced "TYPO3.Flow.object.excludeClasses" with "TYPO3.Flow.object.includeClasses“, due to changes introduced with Flow 3.0.0.

Resolves #11 