### PR TITLE
Changed neos/flow constraint from ~4.0.0 to ~4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "neos-package",
     "description": "Provides a quick and simple way to generate a PDF from a Fluid Template through the MPDF library",
     "require": {
-        "neos/flow": "~4.0.0",
+        "neos/flow": "~4.0",
         "mpdf/mpdf": "*"
     },
     "suggest": {


### PR DESCRIPTION
This change will also allow the package to be used on Neos Flow version 4.0 and higher (4.1, 4.X)