### PR TITLE
TASK: Declare compatible with Flow 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "neos-package",
   "description": "Provides a quick and simple way to generate a PDF from a Fluid Template through the MPDF library",
   "require": {
-    "neos/flow": "^4.0 || ^5.0",
+    "neos/flow": "^4.0 || ^5.0 || ^6.0",
     "mpdf/mpdf": ">7.0"
   },
   "suggest": {


### PR DESCRIPTION
This simply raises the required Flow version, no further adjustments needed,
it seems.